### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 An MCP server for interacting with the [Dub.co](https://dub.co) link shortener API. This server allows AI agents to create, update, and manage short links through your Dub.co account.
 
+<a href="https://glama.ai/mcp/servers/p293dlsvcn">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/p293dlsvcn/badge" alt="Dub.co Server MCP server" />
+</a>
+
 ## Features
 
 - Create short links with custom slugs


### PR DESCRIPTION
This PR adds a badge for the [Dub.co MCP Server](https://glama.ai/mcp/servers/p293dlsvcn) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/p293dlsvcn">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/p293dlsvcn/badge" alt="Dub.co Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.